### PR TITLE
Add input validation functions for Note.Rest and Note.Unpitched

### DIFF
--- a/src/commonMain/kotlin/com/sparetimedevs/ami/music/input/ConvertToInput.kt
+++ b/src/commonMain/kotlin/com/sparetimedevs/ami/music/input/ConvertToInput.kt
@@ -57,8 +57,7 @@ public fun com.sparetimedevs.ami.music.data.kotlin.measure.MeasureAttributes?.to
         key = null // TODO
     )
 
-// TODO this should yield either Pitched, Unpitched, Chord, or Rest.
-public fun Note.toInput(): Pitched =
+public fun Note.toInput(): Any =
     when (this) {
         is Note.Pitched -> {
             Pitched(
@@ -67,9 +66,26 @@ public fun Note.toInput(): Pitched =
                 pitch = this.pitch.toInput()
             )
         }
-        is Note.Chord -> TODO()
-        is Note.Rest -> TODO()
-        is Note.Unpitched -> TODO()
+        is Note.Chord -> {
+            Chord(
+                duration = this.duration.toInput(),
+                noteAttributes = this.noteAttributes.toInput(),
+                rootNote = this.rootNote.toInput(),
+                pitches = this.pitches.map { it.toInput() }
+            )
+        }
+        is Note.Rest -> {
+            Rest(
+                duration = this.duration.toInput(),
+                noteAttributes = this.noteAttributes.toInput()
+            )
+        }
+        is Note.Unpitched -> {
+            Unpitched(
+                duration = this.duration.toInput(),
+                noteAttributes = this.noteAttributes.toInput()
+            )
+        }
     }
 
 public fun com.sparetimedevs.ami.music.data.kotlin.note.NoteDuration.toInput(): NoteDuration =

--- a/src/commonMain/kotlin/com/sparetimedevs/ami/music/input/validation/ValidateNote.kt
+++ b/src/commonMain/kotlin/com/sparetimedevs/ami/music/input/validation/ValidateNote.kt
@@ -28,6 +28,8 @@ import com.sparetimedevs.ami.core.validation.validationErrorForProperty
 import com.sparetimedevs.ami.music.data.kotlin.note.Note
 import com.sparetimedevs.ami.music.data.kotlin.note.Note.Chord
 import com.sparetimedevs.ami.music.data.kotlin.note.Note.Pitched
+import com.sparetimedevs.ami.music.data.kotlin.note.Note.Rest
+import com.sparetimedevs.ami.music.data.kotlin.note.Note.Unpitched
 import com.sparetimedevs.ami.music.data.kotlin.note.NoteAttributes
 import com.sparetimedevs.ami.music.data.kotlin.note.NoteDuration
 import com.sparetimedevs.ami.music.data.kotlin.note.NoteModifier
@@ -48,7 +50,10 @@ public fun validateNote(
                 input.validate(validationIdentifierForNote)
             is com.sparetimedevs.ami.music.input.Chord ->
                 input.validate(validationIdentifierForNote)
-            // TODO add Unpitched, Rest
+            is com.sparetimedevs.ami.music.input.Rest ->
+                input.validate(validationIdentifierForNote)
+            is com.sparetimedevs.ami.music.input.Unpitched ->
+                input.validate(validationIdentifierForNote)
             else ->
                 ValidationError(
                         "Note can't be of type ${input::class.simpleName}",
@@ -83,6 +88,26 @@ public fun com.sparetimedevs.ami.music.input.Chord.validate(
             .combineAllValidationErrors()
     ) { duration, noteAttributes, rootNote, pitches ->
         Chord(duration, noteAttributes, rootNote, pitches)
+    }
+
+public fun com.sparetimedevs.ami.music.input.Rest.validate(
+    validationIdentifier: ValidationIdentifier = NoValidationIdentifier
+): EitherNel<ValidationError, Rest> =
+    Either.zipOrAccumulate(
+        this.duration.validate(validationIdentifier),
+        this.noteAttributes.validate(validationIdentifier)
+    ) { duration, noteAttributes ->
+        Rest(duration, noteAttributes)
+    }
+
+public fun com.sparetimedevs.ami.music.input.Unpitched.validate(
+    validationIdentifier: ValidationIdentifier = NoValidationIdentifier
+): EitherNel<ValidationError, Unpitched> =
+    Either.zipOrAccumulate(
+        this.duration.validate(validationIdentifier),
+        this.noteAttributes.validate(validationIdentifier)
+    ) { duration, noteAttributes ->
+        Unpitched(duration, noteAttributes)
     }
 
 public fun com.sparetimedevs.ami.music.input.NoteDuration.validate(


### PR DESCRIPTION
Add input validation functions for `Note.Rest` and `Note.Unpitched`.

* Add import statements for `Note.Rest` and `Note.Unpitched` in `ValidateNote.kt`.
* Update `validateNote` function to handle `Rest` and `Unpitched` types.
* Add validation functions for `Rest` and `Unpitched` in `ValidateNote.kt`.
* Update `ConvertToInput.kt` to handle `Note.Rest` and `Note.Unpitched` in the `Note.toInput` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sparetimedevs/ami-music-sdk-kotlin?shareId=89323d64-6f25-4e09-b778-d0a6ab95a348).